### PR TITLE
Allow validating URLs before making requests to them

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ __This is a fork of [cpiber/epub-gen-memory](https://github.com/cpiber/epub-gen-
 - Support passing local file path to `cover` option (instead of just URL)
 - Remove the extra new line in the generated ncx chapter title
 - Support img tag with data URL (base64) as src
+- Support validating URLs before requests are made to them
 
 ## Install
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -119,7 +119,7 @@ export class EPub {
     for (let i = 0; i < this.options.fonts.length; i += this.options.batchSize) {
       const fontContents = await Promise.all(
         this.options.fonts.slice(i, i + this.options.batchSize).map(font => {
-          const d = retryFetch(font.url, this.options.fetchTimeout, this.options.retryTimes, this.log)
+          const d = retryFetch(font.url, this.options.fetchTimeout, this.options.retryTimes, this.log, this.options.urlValidator)
             .then(res => (this.log(`Downloaded font ${font.url}`), { ...font, data: res }));
           return this.options.ignoreFailedDownloads
             ? d.catch(reason => (this.warn(`Warning (font ${font.url}): Download failed`, reason), { ...font, data: '' }))
@@ -138,7 +138,7 @@ export class EPub {
     for (let i = 0; i < this.images.length; i += this.options.batchSize) {
       const imageContents = await Promise.all(
         this.images.slice(i, i + this.options.batchSize).map(image => {
-          const d = retryFetch(image.url, this.options.fetchTimeout, this.options.retryTimes, this.log)
+          const d = retryFetch(image.url, this.options.fetchTimeout, this.options.retryTimes, this.log, this.options.urlValidator)
             .then(res => (this.log(`Downloaded image ${image.url}`), { ...image, data: res }));
           return this.options.ignoreFailedDownloads
             ? d.catch(reason => (this.warn(`Warning (image ${image.url}): Download failed`, reason), { ...image, data: '' }))
@@ -155,7 +155,7 @@ export class EPub {
     let coverContent: Buffer | string = ""
 
     if (this.options.cover.startsWith('http')) {
-      coverContent = await retryFetch(this.options.cover, this.options.fetchTimeout, this.options.retryTimes, this.log)
+      coverContent = await retryFetch(this.options.cover, this.options.fetchTimeout, this.options.retryTimes, this.log, this.options.urlValidator)
         .catch(reason => (this.warn(`Warning (cover ${this.options.cover}): Download failed`, reason), ''));
     } else {
       coverContent = fs.readFileSync(this.options.cover)

--- a/lib/util/html.ts
+++ b/lib/util/html.ts
@@ -5,6 +5,8 @@ import { uuid } from './other';
 
 export type CB = typeof imgSrc;
 
+export type UrlValidator = (url: string) => boolean;
+
 export type Image = {
   url: string,
   id: string,

--- a/lib/util/other.ts
+++ b/lib/util/other.ts
@@ -8,8 +8,8 @@ export const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
     return (c === 'x' ? r : r & 0x3 | 0x8).toString(16)
   });
 
-export const retryFetch = async (url: string, timeout: number, retry: number, log: typeof console.log, shouldSkipUrl?: UrlValidator) => {
-  if (shouldSkipUrl?.(url)) {
+export const retryFetch = async (url: string, timeout: number, retry: number, log: typeof console.log, urlValidator?: UrlValidator) => {
+  if (urlValidator?.(url)) {
     throw new Error(`\`${url}\` failed URL validation. Skipping...`);
   }
   for (let i = 0; i < retry - 1; i++) {

--- a/lib/util/other.ts
+++ b/lib/util/other.ts
@@ -1,4 +1,5 @@
 import fetchable from './fetchable';
+import { UrlValidator } from "./html";
 export * from './fetchable';
 
 export const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
@@ -7,7 +8,10 @@ export const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
     return (c === 'x' ? r : r & 0x3 | 0x8).toString(16)
   });
 
-export const retryFetch = async (url: string, timeout: number, retry: number, log: typeof console.log) => {
+export const retryFetch = async (url: string, timeout: number, retry: number, log: typeof console.log, shouldSkipUrl?: UrlValidator) => {
+  if (shouldSkipUrl?.(url)) {
+    throw new Error(`\`${url}\` failed URL validation. Skipping...`);
+  }
   for (let i = 0; i < retry - 1; i++) {
     try {
       return await fetchable(url, timeout);

--- a/lib/util/validate.ts
+++ b/lib/util/validate.ts
@@ -1,5 +1,6 @@
 import ow, { ObjectPredicate, Predicate } from 'ow';
 import { Merge } from 'type-fest';
+import { UrlValidator } from "./html";
 
 export type Chapter = {
   title?: string,
@@ -43,6 +44,7 @@ export type Options = {
   batchSize?: number,
   ignoreFailedDownloads?: boolean,
   verbose?: boolean | LogFn,
+  urlValidator?: UrlValidator,
 };
 
 const name = ow.optional.any(ow.string, ow.array.ofType(ow.string), ow.undefined);

--- a/tests/urlValidation.ts
+++ b/tests/urlValidation.ts
@@ -7,19 +7,19 @@ import epub from '../lib';
  */
 
 (async () => {
-  function shouldSkipUrl(url: string): boolean {
+  function urlValidator(url: string): boolean {
     const protocol = new URL(url).protocol;
     return protocol === "file:" || protocol === "https:";
   }
 
   const epubContent = `<p>Generate EPUB books from HTML with a simple API in Node.js or the browser.</p><p><img src="file:///filepath/that/will/be/ignored"><img src="http://www.alice-in-wonderland.net/wp-content/uploads/1book2.jpg" alt="Image"/><img src="https://url/that/will/be/ignored">`;
   try {
-    await epub({ title: 'EPub Gen', verbose: true, urlValidator: shouldSkipUrl }, [{ content: epubContent }]);
+    await epub({ title: 'EPub Gen', verbose: true, urlValidator }, [{ content: epubContent }]);
     process.exit(-1);
   } catch (err) {
     console.log(`Caught \`${err}\` as expected`);
   }
 
-  const content = await epub({ title: 'EPub Gen', verbose: true, ignoreFailedDownloads: true, urlValidator: shouldSkipUrl }, [{ content: epubContent }]);
+  const content = await epub({ title: 'EPub Gen', verbose: true, ignoreFailedDownloads: true, urlValidator }, [{ content: epubContent }]);
   await writeFile(`${__filename.slice(0, -3)}.epub`, Buffer.from(content));
 })();

--- a/tests/urlValidation.ts
+++ b/tests/urlValidation.ts
@@ -1,0 +1,25 @@
+import { writeFile } from 'fs/promises';
+import epub from '../lib';
+
+/*
+  This test checks that the urlValidator allows skipping requests to "file" and "https" URLs and throws an error if one would be encountered.
+  If ignoreFailedDownloads is turned on, generating the epub should still work fine.
+ */
+
+(async () => {
+  function shouldSkipUrl(url: string): boolean {
+    const protocol = new URL(url).protocol;
+    return protocol === "file:" || protocol === "https:";
+  }
+
+  const epubContent = `<p>Generate EPUB books from HTML with a simple API in Node.js or the browser.</p><p><img src="file:///filepath/that/will/be/ignored"><img src="http://www.alice-in-wonderland.net/wp-content/uploads/1book2.jpg" alt="Image"/><img src="https://url/that/will/be/ignored">`;
+  try {
+    await epub({ title: 'EPub Gen', verbose: true, urlValidator: shouldSkipUrl }, [{ content: epubContent }]);
+    process.exit(-1);
+  } catch (err) {
+    console.log(`Caught \`${err}\` as expected`);
+  }
+
+  const content = await epub({ title: 'EPub Gen', verbose: true, ignoreFailedDownloads: true, urlValidator: shouldSkipUrl }, [{ content: epubContent }]);
+  await writeFile(`${__filename.slice(0, -3)}.epub`, Buffer.from(content));
+})();


### PR DESCRIPTION
 Allow validating URLs before making requests to them to avoid leaking secret information e.g. from local files or internal networks